### PR TITLE
Optimize regexification of search tokens

### DIFF
--- a/lib/mongoid_search/mongoid_search.rb
+++ b/lib/mongoid_search/mongoid_search.rb
@@ -45,7 +45,7 @@ module Mongoid::Search
 
     def search_without_relevance(query, options={})
       return criteria.all if query.blank? && allow_empty_search
-      criteria.send("#{(options[:match]||self.match).to_s}_in", :_keywords => Util.normalize_keywords(query, stem_keywords, ignore_list).map { |q| /#{q}/ })
+      criteria.send("#{(options[:match]||self.match).to_s}_in", :_keywords => Util.normalize_keywords(query, stem_keywords, ignore_list).map { |q| /^#{q}.*/ })
     end
 
     def search_relevant(query, options={})

--- a/spec/mongoid_search_spec.rb
+++ b/spec/mongoid_search_spec.rb
@@ -97,6 +97,10 @@ describe Mongoid::Search do
     Product.search("Olé").size.should == 1
   end
 
+  it "adds good regexes to the criteria" do
+    Product.search("iph").criteria.selector[:_keywords]['$in'].first.should == /^iph.*/
+  end
+
   it "should return results in search even if the case doesn't match" do
     Product.search("oLe").size.should == 1
   end


### PR DESCRIPTION
Currently, `Mongoid::Search` turns your search terms into a list of simple, two-way wildcard regular expressions. However, two-way wildcards are very difficult for the query optimizer to handle, so this change only makes it a one-way wild card. Here's an example, wherein the collection being queried only has 100,000 documents -- note the nscanned value.

``` ruby
Person.collection.create_index '_keywords'

exp = Person.collection.find(:_keywords => {:$in => [/so/]}).explain
exp["nscanned"] # => 973496, almost 10 times the size of the collection
exp["millis"] # => 945
exp["nscannedObjects"] # => 4014
exp["n"] # => 4013

exp = Person.collection.find(:_keywords => {:$in => [/^so.*/]}).explain
exp["nscanned"] # => 4014, only scans one more document than we need
exp["millis"] # => 6
exp["nscannedObjects"] # => 4013
exp["n"] # => 4013
```
