### PR TITLE
Fixed mongoid_search to work with mongoid 3.0rc

### DIFF
--- a/lib/mongoid_search/mongoid_search.rb
+++ b/lib/mongoid_search/mongoid_search.rb
@@ -27,7 +27,7 @@ module Mongoid::Search
 
       field :_keywords, :type => Array
       
-      Gem.loaded_specs["mongoid"].version.to_s.include?("3.0") ? index({_keywords: 1}, {background: true}) : index :_keywords, :background => true
+      Gem.loaded_specs["mongoid"].version.to_s.include?("3.0") ? (index({_keywords: 1}, {background: true})) : (index :_keywords, :background => true)
 
       before_save :set_keywords
     end


### PR DESCRIPTION
The current version of mongoid_search breaks with mongoid 3.0rc because mongoid changed the indexing syntax. I have fixed the syntax to work with mongoid 3.0rc
