### PR TITLE
handling french ligatures during indexing and search

### DIFF
--- a/lib/mongoid_search/util.rb
+++ b/lib/mongoid_search/util.rb
@@ -1,3 +1,4 @@
+# encoding: utf-8
 module Util
 
   def self.keywords(klass, field, stem_keywords, ignore_list)
@@ -31,6 +32,8 @@ module Util
   end
 
   def self.normalize_keywords(text, stem_keywords, ignore_list)
+    ligatures = {"œ"=>"oe", "æ"=>"ae"}
+
     return [] if text.blank?
     text = text.to_s.
       mb_chars.
@@ -39,6 +42,7 @@ module Util
       to_s.
       gsub(/[._:;'"`,?|+={}()!@#%^&*<>~\$\-\\\/\[\]]/, ' '). # strip punctuation
       gsub(/[^[:alnum:]\s]/,'').   # strip accents
+      gsub(/[#{ligatures.keys.join("")}]/) {|c| ligatures[c]}.
       split(' ').
       reject { |word| word.size < 2 }
     text = text.reject { |word| ignore_list.include?(word) } unless ignore_list.blank?

--- a/spec/mongoid_search_spec.rb
+++ b/spec/mongoid_search_spec.rb
@@ -86,6 +86,16 @@ describe Mongoid::Search do
     Variant.search(:name => 'Apple', :color => :white).should eq [variant]
   end
 
+  it "should expand the ligature to ease searching" do
+    # ref: http://en.wikipedia.org/wiki/Typographic_ligature, only for french right now. Rules for other languages are not know
+    variant1 = Variant.create :tags => ["œuvre"].map {|tag| Tag.new(:name => tag)}
+    variant2 = Variant.create :tags => ["æquo"].map {|tag| Tag.new(:name => tag)}
+
+    Variant.search("œuvre").should eq [variant1]
+    Variant.search("oeuvre").should eq [variant1]
+    Variant.search("æquo").should eq [variant2]
+    Variant.search("aequo").should eq [variant2]
+  end
   it "should set the _keywords field with stemmed words if stem is enabled" do
     Product.stem_keywords = true
     @product.save!


### PR DESCRIPTION
Been working on this music library project with lyrics and in french we have words with ligatures like "œuvre" and "æquo" which are often written "oeuvre" and "aequo". This causes problems when searching since a first person can enter some CD or work using the ligature while the other person will search it without. Hence replacing the ligature to the non-ligature version during indexing. 

I've used http://en.wikipedia.org/wiki/Typographic_ligature to find the ligatures utilized in French and did not dare implement those from other languages no knowing the actual grammatical rules of those languages.

Hoping this improves the Gem.
## 

Jean-Marc
