### PR TITLE
Removed Ruby 1.9 specific syntax

### DIFF
--- a/lib/mongoid_search/mongoid_search.rb
+++ b/lib/mongoid_search/mongoid_search.rb
@@ -27,7 +27,7 @@ module Mongoid::Search
 
       field :_keywords, :type => Array
       
-      Gem.loaded_specs["mongoid"].version.to_s.include?("3.0") ? (index({_keywords: 1}, {background: true})) : (index :_keywords, :background => true)
+      Gem.loaded_specs["mongoid"].version.to_s.include?("3.0") ? (index({:_keywords => 1}, {:background => true})) : (index :_keywords, :background => true)
 
       before_save :set_keywords
     end


### PR DESCRIPTION
Hey mate, I found an issue with the mongoid_search.rb file due to some Ruby 1.9 syntax in there. I patched it to help all the poor souls still stuck on 1.8 (like me!)
