### PR TITLE
Crash bug for several fields in :belongs_to association.

### DIFF
--- a/lib/mongoid_search/util.rb
+++ b/lib/mongoid_search/util.rb
@@ -20,7 +20,11 @@ module Mongoid::Search::Util
               normalize_keywords(attribute[method.to_sym])
             end
           else
-            normalize_keywords(attribute.send(method))
+            if method.is_a?(Array)
+              method.map {|m| normalize_keywords attribute[m.to_sym] }
+            else
+              normalize_keywords(attribute.send(method))
+            end
           end
         end
       end

--- a/spec/models/category.rb
+++ b/spec/models/category.rb
@@ -1,6 +1,7 @@
 class Category
   include Mongoid::Document
   field :name
+  field :description
 
   has_many :products
 end

--- a/spec/models/product.rb
+++ b/spec/models/product.rb
@@ -10,6 +10,6 @@ class Product
   belongs_to  :category
   embeds_many :subproducts
 
-  search_in :brand, :name, :outlet, :attrs, :tags => :name, :category => :name,
+  search_in :brand, :name, :outlet, :attrs, :tags => :name, :category => [:name, :description],
             :subproducts => [:brand, :name], :info => [ :summary, :description ]
 end

--- a/spec/mongoid_search_spec.rb
+++ b/spec/mongoid_search_spec.rb
@@ -20,7 +20,7 @@ describe Mongoid::Search do
     @product = Product.create :brand => "Apple",
                               :name => "iPhone",
                               :tags => ["Amazing", "Awesome", "Olé"].map { |tag| Tag.new(:name => tag) },
-                              :category => Category.new(:name => "Mobile"),
+                              :category => Category.new(:name => "Mobile", :description => "Reviews"),
                               :subproducts => [Subproduct.new(:brand => "Apple", :name => "Craddle")],
                               :info => { :summary => "Info-summary",
                                          :description => "Info-description"}
@@ -110,20 +110,20 @@ describe Mongoid::Search do
   it "should set the _keywords field with stemmed words if stem is enabled" do
     Mongoid::Search.stem_keywords = true
     @product.save!
-    @product._keywords.sort.should == ["amaz", "appl", "awesom", "craddl", "iphon", "mobil", "ol", "info", "descript", "summari"].sort
+    @product._keywords.sort.should == ["amaz", "appl", "awesom", "craddl", "iphon", "mobil", "review", "ol", "info", "descript", "summari"].sort
   end
 
   it "should set the _keywords field with custom stemmed words if stem is enabled with a custom lambda" do
     Mongoid::Search.stem_keywords = true
     Mongoid::Search.stem_proc     = Proc.new { |word| word.upcase }
     @product.save!
-    @product._keywords.sort.should == ["AMAZING", "APPLE", "AWESOME", "CRADDLE", "DESCRIPTION", "INFO", "IPHONE", "MOBILE", "OLE", "SUMMARY"]
+    @product._keywords.sort.should == ["AMAZING", "APPLE", "AWESOME", "CRADDLE", "DESCRIPTION", "INFO", "IPHONE", "MOBILE", "OLE", "REVIEWS", "SUMMARY"]
   end
 
   it "should ignore keywords in an ignore list" do
     Mongoid::Search.ignore_list = YAML.load(File.open(File.dirname(__FILE__) + '/config/ignorelist.yml'))["ignorelist"]
     @product.save!
-    @product._keywords.sort.should == ["apple", "craddle", "iphone", "mobile", "ole", "info", "description", "summary"].sort
+    @product._keywords.sort.should == ["apple", "craddle", "iphone", "mobile", "reviews", "ole", "info", "description", "summary"].sort
   end
 
    it "should incorporate numbers as keywords" do
@@ -190,6 +190,10 @@ describe Mongoid::Search do
 
   it "should search for embedded documents" do
     Product.full_text_search("craddle").size.should == 1
+  end
+
+  it "should search for reference documents" do
+    Product.full_text_search("reviews").size.should == 1
   end
 
   it 'should work in a chainable fashion' do


### PR DESCRIPTION
In terms of spec example, you could add additional field :description in Category model and try to fetch this field in search from Product model.

TypeError: [:name, :description] is not a symbol
