### PR TITLE
Use namespace Mongoid::Search for Log class.

### DIFF
--- a/tasks/mongoid_search.rake
+++ b/tasks/mongoid_search.rake
@@ -2,14 +2,14 @@ namespace :mongoid_search do
   desc 'Goes through all documents with search enabled and indexes the keywords.'
   task :index => :environment do
     if Mongoid::Search.classes.blank?
-      Log.log "No model to index keywords.\n"
+      Mongoid::Search::Log.log "No model to index keywords.\n"
     else
       Mongoid::Search.classes.each do |klass|
-        Log.silent = ENV['SILENT']
-        Log.log "\nIndexing documents for #{klass.name}:\n"
+        Mongoid::Search::Log.silent = ENV['SILENT']
+        Mongoid::Search::Log.log "\nIndexing documents for #{klass.name}:\n"
         klass.index_keywords!
       end
-      Log.log "\n\nDone.\n"
+      Mongoid::Search::Log.log "\n\nDone.\n"
     end
   end
 end


### PR DESCRIPTION
Problem with rake task mongoid_search:index in rails application.

rake aborted!
uninitialized constant Log
...
Tasks: TOP => mongoid_search:index
(See full trace by running task with --trace)
