### PR TITLE
Update lib/mongoid_search/util.rb

### DIFF
--- a/lib/mongoid_search/util.rb
+++ b/lib/mongoid_search/util.rb
@@ -29,7 +29,7 @@ module Mongoid::Search::Util
         end
       end
     else
-      value = klass[field]
+      value = klass.send(field)
       value = value.join(' ') if value.respond_to?(:join)
       normalize_keywords(value) if value
     end


### PR DESCRIPTION
If one of the fields in `search_in` is a method, then the old-way `klass[field]` returns nil.
With this fix it executes the method and uses its result. Also, for regular fields it also works fine.
