### PR TITLE
Eager-load models in the :index rake task.

### DIFF
--- a/tasks/mongoid_search.rake
+++ b/tasks/mongoid_search.rake
@@ -1,6 +1,7 @@
 namespace :mongoid_search do
   desc 'Goes through all documents with search enabled and indexes the keywords.'
   task :index => :environment do
+    ::Rails.application.eager_load!
     if Mongoid::Search.classes.blank?
       Mongoid::Search::Log.log "No model to index keywords.\n"
     else


### PR DESCRIPTION
In Rails 4, models are no longer automatically eager-loaded within Rake tasks. This addresses one of the issues mentioned in #67 (`uninitialized class variable @@classes`).
