### PR TITLE
Trim characters option added and configurable

### DIFF
--- a/lib/mongoid_search.rb
+++ b/lib/mongoid_search.rb
@@ -27,6 +27,12 @@ module Mongoid::Search
   mattr_accessor :stem_proc
   @@stem_proc = Proc.new { |word| word.stem }
 
+  # before the text is altered we can trim some characters
+  # it allows us to avoid replacing punctuations such as '-' to ' '
+  # which would not be beneficial in cases like date matching (`2017-10-08`)
+  mattr_accessor :trim_characters
+  @@trim_characters = []
+
   ## Words to ignore
   mattr_accessor :ignore_list
   @@ignore_list = []

--- a/lib/mongoid_search/util.rb
+++ b/lib/mongoid_search/util.rb
@@ -34,6 +34,7 @@ module Mongoid::Search::Util
     ignore_list   = Mongoid::Search.ignore_list
     stem_keywords = Mongoid::Search.stem_keywords
     stem_proc     = Mongoid::Search.stem_proc
+    trim_characters = Mongoid::Search.trim_characters
 
     return [] if text.blank?
     text = text.to_s.
@@ -41,6 +42,7 @@ module Mongoid::Search::Util
       normalize(:kd).
       downcase.
       to_s.
+      gsub(/[#{trim_characters.join("")}]/, '').
       gsub(/[._:;'"`,?|+={}()!@#%^&*<>~\$\-\\\/\[\]]/, ' '). # strip punctuation
       gsub(/[^\s\p{Alnum}]/,'').   # strip accents
       gsub(/[#{ligatures.keys.join("")}]/) {|c| ligatures[c]}.
@@ -48,7 +50,7 @@ module Mongoid::Search::Util
       reject { |word| word.size < Mongoid::Search.minimum_word_size }
     text = text.reject { |word| ignore_list.include?(word) } unless ignore_list.blank?
     text = text.map(&stem_proc) if stem_keywords
+    binding.pry
     text
   end
-
 end

--- a/lib/mongoid_search/util.rb
+++ b/lib/mongoid_search/util.rb
@@ -50,7 +50,6 @@ module Mongoid::Search::Util
       reject { |word| word.size < Mongoid::Search.minimum_word_size }
     text = text.reject { |word| ignore_list.include?(word) } unless ignore_list.blank?
     text = text.map(&stem_proc) if stem_keywords
-    binding.pry
     text
   end
 end


### PR DESCRIPTION
In cases such as `2017-10-08` it takes out the `-` and split up each part of the character chain as a word.

Adding `config.trim_characters = ['-']` fixes the issue on my end, considering the above date will be equal to `20171008`.

It might not suite everyone though, but still a good option to add to the gem.