### PR TITLE
Issue #122: escape regexp special characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ tmtags
 ## RVM
 .rvmrc
 
+## RubyMine
+.idea
+
 ## VIM
 *.swp
 

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -31,7 +31,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments, ExcludedMethods.
 Metrics/BlockLength:
-  Max: 271
+  Max: 300
 
 # Offense count: 1
 Metrics/CyclomaticComplexity:

--- a/lib/mongoid_search/mongoid_search.rb
+++ b/lib/mongoid_search/mongoid_search.rb
@@ -51,7 +51,10 @@ module Mongoid::Search
 
     def query(keywords, options)
       keywords_hash = keywords.map do |kw|
-        kw = Mongoid::Search.regex.call(kw) if Mongoid::Search.regex_search
+        if Mongoid::Search.regex_search
+          escaped_kw = Regexp.escape(kw)
+          kw = Mongoid::Search.regex.call(escaped_kw)
+        end
         { _keywords: kw }
       end
 

--- a/spec/mongoid_search_spec.rb
+++ b/spec/mongoid_search_spec.rb
@@ -3,6 +3,8 @@ require File.expand_path(File.dirname(__FILE__) + '/spec_helper')
 describe Mongoid::Search do
   before(:all) do
     @default_proc = Mongoid::Search.stem_proc
+    @default_strip_symbols = Mongoid::Search.strip_symbols
+    @default_strip_accents = Mongoid::Search.strip_accents
   end
 
   after(:all) do
@@ -239,6 +241,22 @@ describe Mongoid::Search do
 
     it 'should return results in search with a full word if using regex search' do
       expect(Product.full_text_search('iphone').size).to eq 1
+    end
+
+    context 'when query include special characters that should not be stripped' do
+      before do
+        Mongoid::Search.strip_symbols = /[\n]/
+        Mongoid::Search.strip_accents = /[^\s\p{Graph}]/
+      end
+
+      after do
+        Mongoid::Search.strip_symbols = @default_strip_symbols
+        Mongoid::Search.strip_accents = @default_strip_accents
+      end
+
+      it 'should escape regex special characters' do
+        expect(Product.full_text_search('iphone (steve').size).to eq 1
+      end
     end
 
     context 'Match partial words on the beginning' do


### PR DESCRIPTION
Fix for Issue #122 

I've add escaping before passign keyword to `regex.call` to prevent errors. Do we need any additional specs here?
