### PR TITLE
Update Mongoid::Search::Util.normalize_keywords

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.0 (next)
 
 * Your contribution here.
+* [#138](https://github.com/mongoid/mongoid_search/pull/138): Update mongoid::search::util.normalize_keywords - [@yads](https://github.com/yads).
 * [#132](https://github.com/mongoid/mongoid_search/pull/132): Add RELEASING and CONTRIBUTING - [@rtrv](https://github.com/rtrv).
 
 ## 0.3.6

--- a/lib/mongoid_search/util.rb
+++ b/lib/mongoid_search/util.rb
@@ -40,7 +40,7 @@ module Mongoid::Search::Util
     return [] if text.blank?
     text = text.to_s
                .mb_chars
-               .normalize(:kd)
+               .unicode_normalize(:nfkd)
                .downcase
                .to_s
                .gsub(strip_symbols, ' ') # strip symbols


### PR DESCRIPTION
Use unicode_normalize instead of normalize as this is deprecated as of Rails 6.0 and will be removed in Rails 6.1

This may not be compatible with earlier versions of mongoid as this method was added in Ruby 2.2