### PR TITLE
Fix Rails 8.1 deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## 0.5.0 (next)
 * Your contribution here.
+* [#151](https://github.com/mongoid/mongoid_search/pull/151): Remove deprecated `mb_chars` call (Rails 8.1) - [@stanley90](https://github.com/stanley90).
 * [#146](https://github.com/mongoid/mongoid_search/pull/146): Update dependencies and switch to Github Actions - [@yads](https://github.com/yads).
 
 ## 0.4.0

--- a/lib/mongoid_search/util.rb
+++ b/lib/mongoid_search/util.rb
@@ -41,7 +41,6 @@ module Mongoid::Search::Util
     return [] if text.blank?
 
     text = text.to_s
-               .mb_chars
                .unicode_normalize(:nfkd)
                .downcase
                .to_s


### PR DESCRIPTION
Remove deprecated call of `mb_chars`.
Not sure if we should check the Rails version to ensure this gem still works with older versions?